### PR TITLE
fix(tools): `fcc 80` not working for combiner project

### DIFF
--- a/tooling/answers-combiner.md
+++ b/tooling/answers-combiner.md
@@ -7572,3 +7572,21 @@ fn set_rgba(vec: &Vec<u8>, start: usize, end: usize) -> Vec<u8> {
 ```
 
 ### --tests--
+
+- This is the final lesson. Congrats!
+- `null`
+
+## 81
+
+### --description--
+
+### --seed--
+
+```rust
+// Placeholder
+```
+
+### --tests--
+
+- Placeholder
+- `null`

--- a/tooling/lesson.js
+++ b/tooling/lesson.js
@@ -4,6 +4,7 @@ const { getLessonFromFile, getLessonDescription } = require("./parser");
 function runLesson(project, lessonNumber) {
   const answerFile = `./tooling/answers-${project}.md`;
   const lesson = getLessonFromFile(answerFile, lessonNumber);
+  const nextLesson = getLessonFromFile(answerFile, lessonNumber + 1);
   if (project === "combiner") {
     const description = getLessonDescription(lesson)
       .replace("Task:", `${Colour.FgMagenta}Task:${Colour.Reset}`)
@@ -20,11 +21,12 @@ function runLesson(project, lessonNumber) {
       }\n`
     );
     console.log(description);
-    console.log(
-      `When you are done, type the following for the next lesson:\n\t${
-        Colour.FgCyan
-      }$ fcc ${lessonNumber + 1}${Colour.Reset}\n`
-    );
+    if (!!nextLesson) {
+      console.log(
+        `When you are done, type the following for the next lesson:\n\t${Colour.FgCyan
+        }$ fcc ${lessonNumber + 1}${Colour.Reset}\n`
+      );
+    }
   } else {
     console.log(getLessonDescription(lesson));
   }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

`fcc 81` command was causing a bug because the parser looks for `81` to know where `80` ends. this PR adds a placeholder `81` and updates the logic to not show the prompt for the next step if there isn't one. 
