### PR TITLE
fix: add comma to example enum in combiner lesson 72

### DIFF
--- a/tooling/locales/en/answers-combiner.md
+++ b/tooling/locales/en/answers-combiner.md
@@ -6154,7 +6154,7 @@ To handle errors more clearly, you can create an _enum_ to represent the possibl
 ```rust
     enum MyErrors {
       BrainTooTired,
-      TimeOfDay(String)
+      TimeOfDay(String),
       CoffeeCupEmpty,
     }
 


### PR DESCRIPTION
Added comma in example enum.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x ] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
